### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IAElegantSheet 
 [![Build Status](https://travis-ci.org/ikhsan/IAElegantSheet.svg?branch=master)](https://travis-ci.org/ikhsan/IAElegantSheet)
-[![Cocoapods](https://cocoapod-badges.herokuapp.com/v/IAElegantSheet/badge.png)](http://cocoapods.org/?q=iaelegantsheet)
+[![CocoaPods](https://cocoapod-badges.herokuapp.com/v/IAElegantSheet/badge.png)](http://cocoapods.org/?q=iaelegantsheet)
 [![Coverage Status](https://coveralls.io/repos/ikhsan/IAElegantSheet/badge.svg?branch=master)](https://coveralls.io/r/ikhsan/IAElegantSheet?branch=master)
 
 Another UIActionSheet but more elegant. Elegant to code and elegant to see. Using Roboto Condensed as default font.


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
